### PR TITLE
Remove excess point at the end of the bezier_curve() output

### DIFF
--- a/src/bezier_curve.scad
+++ b/src/bezier_curve.scad
@@ -54,9 +54,8 @@ function _bezier_curve_point(t, points) =
 
 function bezier_curve(t_step, points) = 
     let(
-        pts = concat([
-            for(t = [0: t_step: 1]) 
-                _bezier_curve_point(t, points)
-        ], [_bezier_curve_point(1, points)])
+        pts = [ for(t = [0: t_step: 1]) 
+            _bezier_curve_point(t, points)
+        ]
     ) 
     len(points[0]) == 3 ? pts : [for(pt = pts) __to2d(pt)];

--- a/src/bezier_curve.scad
+++ b/src/bezier_curve.scad
@@ -54,8 +54,9 @@ function _bezier_curve_point(t, points) =
 
 function bezier_curve(t_step, points) = 
     let(
-        pts = [ for(t = [0: t_step: 1]) 
-            _bezier_curve_point(t, points)
-        ]
+        pts = concat([
+            for(t = [0: ceil(1 / t_step) - 1])
+                _bezier_curve_point(t * t_step, points)
+        ], [_bezier_curve_point(1, points)])
     ) 
     len(points[0]) == 3 ? pts : [for(pt = pts) __to2d(pt)];


### PR DESCRIPTION
`bezier_curve()` produces an excess point at the end of the output array. This may cause undesirable effects when the output is fed to e.g. `path_extrude()`:
![image](https://user-images.githubusercontent.com/536698/39460193-af4212bc-4d2b-11e8-84fc-24096bae6417.png)

Proposed fix attached and seems to work:
![image](https://user-images.githubusercontent.com/536698/39460202-c2e408de-4d2b-11e8-999f-816f3670cbd4.png)

The code to reproduce:
```
include <../src/bezier_curve.scad>;

curve_pts = [[5,5,0],[10,10,10],[20,20,20]];
path_pts = bezier_curve(0.1,curve_pts);
echo(path_pts=path_pts); // See the output

include <../src/polysections.scad>;
include <../src/rotate_p.scad>;
include <../src/path_extrude.scad>;

shape_pts = [[5, -5], [5, 5], [-5, 5], [-5, -5]]; // 10mm square
path_extrude(shape_pts,path_pts,triangles="SOLID");
```