### PR TITLE
Fixed util/parse_number for numbers with >2 digits

### DIFF
--- a/src/util/_impl/_parse_number_impl.scad
+++ b/src/util/_impl/_parse_number_impl.scad
@@ -4,7 +4,7 @@ use <../split_str.scad>
 function _str_to_int(t) =  ord(t) - 48;
     
 function _parse_positive_int(t, value = 0, i = 0) =
-    i == len(t) ? value : _parse_positive_int(t, value * 10 ^ i + _str_to_int(t[i]), i + 1);
+    i == len(t) ? value : _parse_positive_int(t, value * 10 + _str_to_int(t[i]), i + 1);
 
 function _parse_positive_number(t) =
     len(search(".", t)) == 0 ? _parse_positive_int(t) :

--- a/test/util/test_parse_number.scad
+++ b/test/util/test_parse_number.scad
@@ -5,6 +5,7 @@ module test_parse_number() {
 
     assert(11 == parse_number("10") + 1);   
     assert(-1.1 == parse_number("-1.1"));  
+    assert(12345 == parse_number("12345"));  
 }
 
 test_parse_number();


### PR DESCRIPTION
In these cases the digits at the start of the number would be multiplied by too many powers of ten, inflating the result (123 -> 1203, 1234 -> 1203004, etc).